### PR TITLE
Updated links & marketing position

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -24,9 +24,10 @@ require(__DIR__.'/globals.php');
 			</ul>
 			<span id="join_us_header" type="button" class="btn"><a href="http://www.meetup.com/Girl-Develop-It-Salt-Lake-City/" target="_blank">Join Us</a></span>
 			<ul id="quick_links">
-				<li class="bold"><a href="https://docs.google.com/forms/d/1NMKQmjv1rkwfyQovEnzfA12kedAraMMZoXhTUGZygHk/viewform" target="_blank">Community Survey</a></li>
+				<!--<li class="bold"><a href="https://docs.google.com/forms/d/1NMKQmjv1rkwfyQovEnzfA12kedAraMMZoXhTUGZygHk/viewform" target="_blank">Community Survey</a></li>-->
 				<!--<li><a href="<?=$MAINPATH?>" target="_blank">Mentorship (Create)</a></li>-->
 				<li><a href="https://docs.google.com/a/girldevelopit.com/forms/d/1QvhrlamutZIP8mmBldHDkPEeGwcS4UQuzOvDPlxMW84/viewform" target="_blank">Scholarships</a></li>
+				<li><a href="<?=$MAINPATH?>pages/howyoucanhelp.php" target="_blank">How You Can Help</a></li>
 				<!--<li><a href="<?=$MAINPATH?>" target="_blank">Contact Us (Create)</a></li>-->
 			</ul>
 		</header>

--- a/includes/header.php
+++ b/includes/header.php
@@ -49,16 +49,16 @@ require(__DIR__.'/globals.php');
 					</li>
 					<li><a class="no_link"><span>Learn</span></a>
 						<ul>
-							<li><a href="<?=$MAINPATH?>pages/online_resources.php">Online Resources</a></li>
+							<!--<li><a href="<?=$MAINPATH?>pages/online_resources.php">Online Resources</a></li>-->
 							<li><a href="<?=$MAINPATH?>pages/kids_STEM.php">Kids STEM Resources</a></li>
-							<li><a href="<?=$MAINPATH?>pages/local_bootcamps.php">Local Bootcamps</a></li>
+							<!--<li><a href="<?=$MAINPATH?>pages/local_bootcamps.php">Local Bootcamps</a></li>-->
 						</ul>
 					</li>
 					<li><a class="no_link"><span>Work</span></a>
 						<ul>
 							<!--<li><a href="<?=$MAINPATH?>pages/startup_support.php">Startup Support</a></li>-->
-							<li><a href="<?=$MAINPATH?>pages/freelancing.php">Freelancing Sites</a></li>
-							<li><a href="<?=$MAINPATH?>pages/jobsearching.php">Job Searching Sites</a></li>
+							<!--<li><a href="<?=$MAINPATH?>pages/freelancing.php">Freelancing Sites</a></li>-->
+							<!--<li><a href="<?=$MAINPATH?>pages/jobsearching.php">Job Searching Sites</a></li>-->
 							<li><a href="<?=$MAINPATH?>pages/local_tech_companies.php">Local Tech Companies</a></li>
 						</ul>
 					</li>

--- a/includes/header.php
+++ b/includes/header.php
@@ -19,7 +19,7 @@ require(__DIR__.'/globals.php');
 			<ul class="social_media">
 				<li><a href="http://www.meetup.com/Girl-Develop-It-Salt-Lake-City/" target="_blank"><i class="fa fa-calendar"></i></a></li>
 				<li><a href="https://twitter.com/gdiSLC" target="_blank"><i class="fa fa-twitter"></i></a></li>
-				<li><a href="https://www.facebook.com/groups/gdislc/" target="_blank"><i class="fa fa-facebook-square"></i></a></li>
+				<li><a href="https://www.facebook.com/gdislc" target="_blank"><i class="fa fa-facebook-square"></i></a></li>
 				<li><a href="http://www.linkedin.com/groups?gid=6630862" target="_blank"><i class="fa fa-linkedin"></i></a></li>
 			</ul>
 			<span id="join_us_header" type="button" class="btn"><a href="http://www.meetup.com/Girl-Develop-It-Salt-Lake-City/" target="_blank">Join Us</a></span>
@@ -41,7 +41,7 @@ require(__DIR__.'/globals.php');
 					</li>
 					<li><a class="no_link"><span>Connect</span></a>
 						<ul>
-							<li><a href="<?=$MAINPATH?>pages/local_user_groups.php">Local User Groups</a></li>
+							<!--<li><a href="<?=$MAINPATH?>pages/local_user_groups.php">Local User Groups</a></li>-->
 							<li><a href="<?=$MAINPATH?>pages/women_in_tech.php">Women in Tech</a></li>
 							<li><a href="<?=$MAINPATH?>pages/tech_conferences.php">Tech Conferences</a></li>
 							<li><a href="<?=$MAINPATH?>pages/local_tech_events.php">Local Tech Events</a></li>

--- a/pages/howyoucanhelp.php
+++ b/pages/howyoucanhelp.php
@@ -11,11 +11,11 @@ require(__DIR__.'/../includes/header.php');
 		<h3>Estimated Commitment:</h3> 5-10 hours/month
 	</p>
 	<hr>
-	<p><h2>Marketing & Advertising</h2>
+	<!--<p><h2>Marketing & Advertising</h2>
 		We are looking for anyone who is interested in helping us in this area. We would love to have someone manage our social media accounts (Facebook, Twitter) and to work with event hosts to figure out the best ways to advertise their events. This is a great way to help spread the word and to gain valuable experience for your resume!<br><br>
 		<h3>Estimated Commitment:</h3> 4-6 hours/month
 	</p>
-	<hr>
+	<hr>-->
 	<p><h2>Mentorship Program</h2>
 		Jillaire is our current Mentorship Program Director. She would love to have your help in reaching out to mentors, gathering information from mentees, and keeping track of how their progress is going.<br><br>
 		<h3>Estimated Commitment:</h3> 2-3 hours/month


### PR DESCRIPTION
Removed links since we're migrating them to our Pinterest page:
- Local User Groups
- Online Resources
- Local Bootcamps
- Freelancing Sites
- Job Searching Sites

Removed 'Community Survey' from quick links since we're not really using data from that survey right now. 

Commented out the marketing section in 'How You Can Help'. Added a quick link to 'How You Can Help'.